### PR TITLE
Change escaping from block to escaper

### DIFF
--- a/src/guides/v2.3/ui_comp_guide/components/ui-htmlcontent.md
+++ b/src/guides/v2.3/ui_comp_guide/components/ui-htmlcontent.md
@@ -72,11 +72,11 @@ Template `Vendor/Module/view/adminhtml/templates/template.phtml`:
 
 ```php
 <?php
-/** @var Magento\Backend\Block\Template $block */
+/** @var \Magento\Framework\Escaper $escaper */
 ?>
 
 <div>
-    <b><?= $block->escapeHtml(__('Custom template.')); ?></b>
+    <b><?= $escaper->escapeHtml(__('Custom template.')); ?></b>
 </div>
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) changes deprecated $block->escapeHtml() to $escaper->escapeHtml()

## Affected DevDocs pages

-  https://devdocs.magento.com/guides/v2.4/ui_comp_guide/components/ui-htmlcontent.html

## Links to Magento source code

-  https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/View/Element/AbstractBlock.php#L900
